### PR TITLE
Update skid_buffer.sv

### DIFF
--- a/skid_buffer.sv
+++ b/skid_buffer.sv
@@ -98,7 +98,7 @@ end
 -------------------------------------------------------------------------------------------------------------------------------*/
 assign o_ready = ready_rg                                   ;        
 assign o_data  = bypass_rg ? i_data  : data_rg              ;        // Data mux
-assign o_valid = bypass_rg ? (i_valid & ready_rg) : 1'b1    ;        // Data valid mux
+assign o_valid = bypass_rg ? i_valid : 1'b1    ;        // Data valid mux
 
 
 endmodule


### PR DESCRIPTION
Hey, I found an optimization. The ready_rg must be 1'b1 If bypass_rg is 1'b1. So we don't need `i_valid & ready_rg`, just `i_valid` is enough